### PR TITLE
Publish on zazuko.com domain

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,3 +22,4 @@ jobs:
           email: noreply@zazuko.com
           build_dir: build
           jekyll: no
+          cname: data-centric.zazuko.com

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           node-version: 18
       - run: npm ci
-      - run: npm run build -- --config docusaurus.prod.config.js
+      - run: npm run build
       - uses: Cecilapp/GitHub-Pages-deploy@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docusaurus.prod.config.js
+++ b/docusaurus.prod.config.js
@@ -2,5 +2,5 @@ const baseConfig = require('./docusaurus.config.js')
 
 module.exports = {
   ...baseConfig,
-  baseUrl: '/data-centric.zazuko.com/'
+  baseUrl: '/'
 }

--- a/docusaurus.prod.config.js
+++ b/docusaurus.prod.config.js
@@ -1,6 +1,0 @@
-const baseConfig = require('./docusaurus.config.js')
-
-module.exports = {
-  ...baseConfig,
-  baseUrl: '/'
-}


### PR DESCRIPTION
This configures the deployment to GitHub Pages to be served under the zazuko.com domain name.

Once the pipeline is executed successfully, we will need to adjust the setting in the GitHub project settings to use the right domain.